### PR TITLE
Allow use of modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ var CodeMirrorEditor = React.createClass({
   componentDidMount: function() {
     var isTextArea = this.props.forceTextArea || IS_MOBILE;
     if (!isTextArea) {
+      this.requireMode();
       this.editor = CodeMirror.fromTextArea(this.refs.editor.getDOMNode(), this.props);
       this.editor.on('change', this.handleChange);
     }
@@ -53,6 +54,12 @@ var CodeMirrorEditor = React.createClass({
       }
     }
   },
+
+  requireMode: function() {
+    var mode = this.props.mode;
+    if (!mode) return;
+    require('codemirror/mode/'+mode+'/'+mode+'.js');
+  }
 
   handleChange: function() {
     if (this.editor) {


### PR DESCRIPTION
Hey there,

I'm currently using this component in my project using webpack. 
It seems that modes, like `htmlmixed` are not available. I don't know if it's specific to my build system (i.e. webpack) or if it was a defect of the component since the beginning. 

Anyway, here is a patch which is working is my case. Feel free to merge to refuse it. 